### PR TITLE
add checks and install different tensorflow version when no AVX support

### DIFF
--- a/install_EcoAssist.command
+++ b/install_EcoAssist.command
@@ -50,6 +50,42 @@ echo "Path to conda.sh: $PATH2CONDA_SH"
 # shellcheck source=src/conda.sh
 source "$PATH2CONDA_SH"
 
+function fetch_os_type() {
+  echo "Checking OS type and version..."
+  OSver="unknown"  # default value
+  uname_output="$(uname -a)"
+  echo "$uname_output"
+  # macOS
+  if echo "$uname_output" | grep -i darwin >/dev/null 2>&1; then
+    # Fetch macOS version
+    sw_vers_output="$(sw_vers | grep -e ProductVersion)"
+    echo "$sw_vers_output"
+    OSver="$(echo "$sw_vers_output" | cut -c 17-)"
+    macOSmajor="$(echo "$OSver" | cut -f 1 -d '.')"
+    macOSminor="$(echo "$OSver" | cut -f 2 -d '.')"
+    # Make sure OSver is supported
+    if [[ "${macOSmajor}" = 10 ]] && [[ "${macOSminor}" < "${MACOSSUPPORTED}" ]]; then
+      die "Sorry, this version of macOS (10.$macOSminor) is not supported. The minimum version is 10.$MACOSSUPPORTED."
+    fi
+    # Fix for non-English Unicode systems on MAC
+    if [[ -z "${LC_ALL:-}" ]]; then
+      export LC_ALL=en_US.UTF-8
+    fi
+
+    if [[ -z "${LANG:-}" ]]; then
+      export LANG=en_US.UTF-8
+    fi
+    OS="osx"
+  # Linux
+  elif echo "$uname_output" | grep -i linux >/dev/null 2>&1; then
+    OS="linux"
+  else
+    die "Sorry, the installer only supports Linux and macOS, quitting installer"
+  fi
+}
+
+fetch_os_type
+
 conda env remove -n ecoassistcondaenv
 conda create -n ecoassistcondaenv python==3.7 -y
 conda activate ecoassistcondaenv
@@ -57,6 +93,30 @@ pip install --upgrade pip setuptools wheel
 pip install --upgrade pip
 conda install -c conda-forge requests=2.26.0 -y
 pip install -r EcoAssist/requirements.txt
+
+## Check if CPU supports AVX instruction set, and install precompiled TensorFlow if it isn't,
+case $OS in
+linux*)
+  if ! lscpu | grep -q " avx "; then
+    echo "AVX is not supported by this CPU! Installing a version of TensorFlow compiled for older CPUs..."
+    pip uninstall tensorflow -y
+    pip install https://github.com/spinalcordtoolbox/docker-tensorflow-builder/releases/download/v1.15.5-py3.7/tensorflow-1.15.5-cp37-cp37m-linux_x86_64.whl
+  else
+    echo "AVX is supported on this Linux machine. Keeping default TensorFlow..."
+  fi
+  ;;
+osx)
+  if sysctl machdep.cpu.brand_string | grep -q "Apple M1"; then
+    echo "AVX is not supported on M1 Macs! Installing a version of TensorFlow compiled for M1 Macs..."
+    pip uninstall tensorflow -y
+    pip install https://github.com/spinalcordtoolbox/docker-tensorflow-builder/releases/download/v1.15.5-py3.7/tensorflow-1.15.0-py3-none-any.whl
+    pip freeze
+  else
+    echo "AVX is supported on this macOS machine. Keeping default TensorFlow..."
+  fi
+  ;;
+esac
+
 conda deactivate
 
 kill $PMSETPID


### PR DESCRIPTION
The added logic will check if the system has AVX support (which M1 macbooks don't) and install a different version of tensorflow compiled without AVX instructions. This way `tf_check.py` will run ok on M1 laptops and Linux laptops with older CPUs.