### PR TITLE
Fixed a CUDA out of memory bug

### DIFF
--- a/EcoAssist_GUI.py
+++ b/EcoAssist_GUI.py
@@ -1136,8 +1136,8 @@ def extract_label_map_from_model(model_file):
     # import module from cameratraps dir
     from cameratraps.detection.pytorch_detector import PTDetector
             
-    # load model
-    detector = PTDetector(model_file)
+    # load model, but only on CPU to avoid have it stay in GPU memory as not needed during detection (probably should be deleted if not needed)
+    detector = PTDetector(model_file,True)
     
     # log
     print(f"detector: {detector}")


### PR DESCRIPTION
Fixed a CUDA out of memory bug when detecting with a custom model.  The model was loaded onto the GPU when getting the custom labels, however it was loaded again during actual detection, resulting on double the memory use. The model is no only loaded on the CPU when getting the custom labels, leaving the GPU free form the detection. model. No slow down as this is not a GPU required operation.