### PR TITLE
Remove get_python_interprator() usage and hard-coded interpreter paths for portable environment compatibility

### DIFF
--- a/AddaxAI_GUI.py
+++ b/AddaxAI_GUI.py
@@ -2168,7 +2168,7 @@ def open_annotation_windows(recognition_file, class_list_txt, file_list_txt, lab
     # init paths
     labelImg_dir = os.path.join(AddaxAI_files, "Human-in-the-loop")
     labelImg_script = os.path.join(labelImg_dir, "labelImg.py")
-    python_executable = get_python_interprator("base")
+    python_executable = sys.executable
 
     # create command
     command_args = []
@@ -2356,13 +2356,6 @@ def open_annotation_windows(recognition_file, class_list_txt, file_list_txt, lab
                                                                 change_hitl_var_in_json(recognition_file, "done"),
                                                                 update_frame_states()])
             btn_hitl_final_export_n.grid(row=0, column=1, rowspan=1, sticky='nesw', padx=5)
-
-# os dependent python executables
-def get_python_interprator(env_name):
-    if platform.system() == 'Windows':
-        return os.path.join(AddaxAI_files, "envs", f"env-{env_name}", "python.exe")
-    else:
-        return os.path.join(AddaxAI_files, "envs", f"env-{env_name}", "bin", "python")
 
 # get the images and xmls from annotation session and store them with unique filename
 def uniquify_and_move_img_and_xml_from_filelist(file_list_txt, recognition_file, hitl_final_window):
@@ -2750,7 +2743,7 @@ def classify_detections(json_fpath, data_type, simple_mode = False):
             cls_tax_levels_idx = model_vars["var_tax_levels_idx"] # take idx from model vars
         
     # init paths
-    python_executable = get_python_interprator(cls_model_env)
+    python_executable = sys.executable
     inference_script = os.path.join(AddaxAI_files, "AddaxAI", "classification_utils", "model_types", cls_model_type, "classify_detections.py")
 
     # create command
@@ -2954,7 +2947,7 @@ def deploy_model(path_to_image_folder, selected_options, data_type, simple_mode 
     process_video_py = os.path.join(AddaxAI_files, "cameratraps", "megadetector", "detection", "process_video.py")
     video_recognition_file = "--output_json_file=" + os.path.join(chosen_folder, "video_recognition_file.json")
     GPU_param = "Unknown"
-    python_executable = get_python_interprator("base")
+    python_executable = sys.executable
 
     # select model based on user input via dropdown menu, or take MDv5a for simple mode 
     custom_model_bool = False
@@ -5033,7 +5026,7 @@ def deploy_speciesnet(chosen_folder, sppnet_output_window, simple_mode = False):
     
     # prepare variables
     chosen_folder = str(Path(chosen_folder))
-    python_executable = get_python_interprator("speciesnet")
+    python_executable = sys.executable
     sppnet_output_file = os.path.join(chosen_folder, "sppnet_output_file.json")
 
     # save settings for next time

--- a/main.py
+++ b/main.py
@@ -10,29 +10,21 @@ import platform
 
 print("\n")
 
-# check os
 system = platform.system()
-
-# os dependent python executables
-def get_python_interprator(env_name):
-    if system == 'Windows':
-        return os.path.join(AddaxAI_files, "envs", f"env-{env_name}", "python.exe")
-    else:
-        return os.path.join(AddaxAI_files, "envs", f"env-{env_name}", "bin", "python")
 
 # clean path
 if getattr(sys, 'frozen', False):
     AddaxAI_files = os.path.dirname(sys.executable)
 else:
     AddaxAI_files = os.path.dirname(os.path.abspath(__file__))
-    
+
 if AddaxAI_files.endswith("main.app/Contents/MacOS"):
     AddaxAI_files = AddaxAI_files.replace("main.app/Contents/MacOS", "")
-    
+
 if AddaxAI_files.endswith(".app/Contents/MacOS"):
     AddaxAI_files = os.path.dirname(os.path.dirname(os.path.dirname(AddaxAI_files)))
 
-# init paths    
+# init paths
 GUI_script = os.path.join(AddaxAI_files, "AddaxAI", "AddaxAI_GUI.py")
 first_startup_file = os.path.join(AddaxAI_files, "first-startup.txt")
 
@@ -40,23 +32,22 @@ first_startup_file = os.path.join(AddaxAI_files, "first-startup.txt")
 print(f"        AddaxAI_files: {AddaxAI_files}")
 print(f"       sys.executable: {sys.executable.replace(AddaxAI_files, '.')}")
 print(f"           GUI_script: {GUI_script.replace(AddaxAI_files, '.')}")
+print(f"    python_executable: using current interpreter")
 
-# python executable
-python_executable = get_python_interprator("base")
-print(f"    python_executable: {python_executable.replace(AddaxAI_files, '.')}")
-
-# cuda toolkit
+#cuda toolkit
 cuda_toolkit_path = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
 print(f"    cuda_toolkit_path: {cuda_toolkit_path}")
 
-# run the GUI script
-print("\nOpening application...") 
+# run the GUI script using CURRENT Python environment
+print("\nOpening application...")
+
+run_cmd = [sys.executable, GUI_script]
+
 if system == 'Windows':
     if sys.executable.endswith("debug.exe"):
-        subprocess.run([get_python_interprator("base"), GUI_script])
-        input("Press [Enter] to close console window...") # keep console open after closing app
+        subprocess.run(run_cmd)
+        input("Press [Enter] to close console window...")
     else:
-        subprocess.run([get_python_interprator("base"), GUI_script],
-                       creationflags=subprocess.CREATE_NO_WINDOW)
+        subprocess.run(run_cmd, creationflags=subprocess.CREATE_NO_WINDOW)
 else:
-    subprocess.run([get_python_interprator("base"), GUI_script])
+    subprocess.run(run_cmd)


### PR DESCRIPTION
Issue #98. I removed get_python_interprator() in both main.py and Addax_GUI.py. This removes the hard-coded virtual environment location. 