### PR TITLE
Fix Windows subprocess output decoding during initial setup

### DIFF
--- a/backend/app/utils/subprocess_runner.py
+++ b/backend/app/utils/subprocess_runner.py
@@ -64,7 +64,9 @@ def stream_with_tail(
 
     Each non-empty stripped line is forwarded to `on_line` (for live
     progress / parsing) and appended to a ring buffer of the last
-    `max_tail` lines. Blocks until the subprocess terminates.
+    `max_tail` lines. Output is decoded as UTF-8 with replacement for
+    malformed bytes so Windows' locale encoding cannot abort a run.
+    Blocks until the subprocess terminates.
 
     `popen_factory` lets callers swap in a process-group launcher
     (e.g. `app.core.subprocess_group.popen_group`) so cancellation can
@@ -90,6 +92,8 @@ def stream_with_tail(
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         bufsize=1,
         env=env,
         cwd=str(cwd) if cwd else None,

--- a/backend/tests/utils/test_subprocess_runner.py
+++ b/backend/tests/utils/test_subprocess_runner.py
@@ -1,0 +1,67 @@
+"""Tests for locale-independent streamed subprocess output."""
+
+from __future__ import annotations
+
+import io
+import subprocess
+import sys
+from typing import Any, cast
+
+from app.utils.subprocess_runner import stream_with_tail
+
+
+class _CompletedProcess:
+    """Small Popen stand-in for inspecting how the runner opens pipes."""
+
+    def __init__(self, output: str = "done\n", returncode: int = 0) -> None:
+        self.stdout = io.StringIO(output)
+        self.returncode = returncode
+
+    def poll(self) -> int:
+        return self.returncode
+
+    def wait(self) -> int:
+        return self.returncode
+
+
+def test_popen_uses_utf8_with_replacement() -> None:
+    observed: dict[str, Any] = {}
+
+    def factory(_cmd: list[str], **kwargs: Any) -> subprocess.Popen[Any]:
+        observed.update(kwargs)
+        return cast(subprocess.Popen[Any], _CompletedProcess())
+
+    result = stream_with_tail(["example"], popen_factory=factory)
+
+    assert result.output_tail == ["done"]
+    assert observed["text"] is True
+    assert observed["encoding"] == "utf-8"
+    assert observed["errors"] == "replace"
+
+
+def test_stream_decodes_utf8_and_replaces_malformed_bytes() -> None:
+    expected_line = "日本語 🦌"
+    payload = expected_line.encode("utf-8") + b"\nbroken:\x81\n"
+    script = (
+        "import sys; "
+        f"sys.stdout.buffer.write(bytes.fromhex('{payload.hex()}')); "
+        "sys.stdout.buffer.flush()"
+    )
+    seen: list[str] = []
+
+    result = stream_with_tail([sys.executable, "-c", script], on_line=seen.append)
+
+    assert result.returncode == 0
+    assert result.output_tail == [expected_line, "broken:\ufffd"]
+    assert result.last_line == "broken:\ufffd"
+    assert seen == result.output_tail
+
+
+def test_nonzero_exit_keeps_output_tail() -> None:
+    script = "import sys; print('failure detail', flush=True); sys.exit(7)"
+
+    result = stream_with_tail([sys.executable, "-c", script])
+
+    assert result.returncode == 7
+    assert result.last_line == "failure detail"
+    assert result.output_tail == ["failure detail"]


### PR DESCRIPTION
## What changed

- Decode streamed subprocess output explicitly as UTF-8.
- Replace malformed bytes instead of aborting the subprocess reader.
- Add Windows regression coverage for UTF-8 Japanese/emoji output, malformed bytes, and non-zero exits.

## Why

On Japanese Windows systems, `subprocess.Popen(text=True)` inherited the `cp932` locale. Micromamba emits UTF-8 output during initial environment setup, so a byte sequence that is invalid in `cp932` raised `UnicodeDecodeError` and aborted creation of `env-addaxai-base`.

## Impact

Initial setup can continue even when micromamba emits UTF-8 or an unexpected malformed byte. Progress callbacks and the captured diagnostic tail retain their existing behavior.

## Validation

- `python -X utf8 -m pytest tests/utils/test_subprocess_runner.py tests/ml/test_environment_progress.py -q --tb=short --no-cov` — 12 passed
- `python -m ruff check app tests` — passed
- `python -m mypy --follow-imports=skip app/utils/subprocess_runner.py tests/utils/test_subprocess_runner.py` — passed
- Full backend suite in UTF-8 mode — 1345 passed, 84 skipped, 71 failed; failures are existing Windows path/platform assumptions in unrelated legacy-install, deployment-split, annotated-copy, separate-folder, output-folder, and ExifTool tests.
