### PR TITLE
Make MDv1000-cedar detect at all

### DIFF
--- a/backend/app/ml/envs/addaxai-base/darwin/environment.yml
+++ b/backend/app/ml/envs/addaxai-base/darwin/environment.yml
@@ -36,5 +36,15 @@ dependencies:
     # cannot load the Windows certificate store (ssl ASN1 error, beta
     # report 2026-06-10). Installing a wheel skips setup.py entirely.
     - ultralytics-yolov5 @ https://huggingface.co/Addax-Data-Science/pip-wheels/resolve/main/ultralytics_yolov5-0.1.1-py3-none-any.whl#sha256=d532e62d6d7cd6c7381e4453810f31f10fd269cf9f237494bc570e74168dc2e1
-    - megadetector==10.0.18
+    - megadetector==10.0.24
+    # MDv1000-cedar is the only model in the zoo with a YOLOv9 architecture,
+    # and megadetector loads it through this package. Upstream treats each
+    # YOLO backend as an optional extra and dropped this one as a dependency
+    # in 10.0.20, so we pin it here; without it cedar fails to load at all.
+    # 10.0.23 is also the first release that runs cedar correctly: before it,
+    # cedar's anchor-free output went through the YOLOv5-shaped NMS, which
+    # read anchor positions as class ids and failed every batch. That crashed
+    # process_video with "exit code 1" and made images silently return
+    # nothing (beta report 2026-07-30).
+    - yolov9pip==0.0.4
     - ultralytics==8.3.177

--- a/backend/app/ml/envs/addaxai-base/linux/environment.yml
+++ b/backend/app/ml/envs/addaxai-base/linux/environment.yml
@@ -14,7 +14,7 @@ dependencies:
     # GPU acceleration is available out of the box, including RTX
     # 50-series (Blackwell, sm_120) with native kernels instead of the
     # slow PTX JIT fallback. Needs NVIDIA driver >= 555. torch 2.8 still
-    # satisfies megadetector 10.0.18: it dropped the old `mkl<=2021.4.0`
+    # satisfies megadetector 10.0.24: it dropped the old `mkl<=2021.4.0`
     # constraint (so megadetector's `mkl==2024.0` resolves) and is not
     # 2.4.0 (which ultralytics 8.3.177 excludes on win32; linux kept on
     # the same version for parity). Use --extra-index-url (not
@@ -49,5 +49,15 @@ dependencies:
     # cannot load the Windows certificate store (ssl ASN1 error, beta
     # report 2026-06-10). Installing a wheel skips setup.py entirely.
     - ultralytics-yolov5 @ https://huggingface.co/Addax-Data-Science/pip-wheels/resolve/main/ultralytics_yolov5-0.1.1-py3-none-any.whl#sha256=d532e62d6d7cd6c7381e4453810f31f10fd269cf9f237494bc570e74168dc2e1
-    - megadetector==10.0.18
+    - megadetector==10.0.24
+    # MDv1000-cedar is the only model in the zoo with a YOLOv9 architecture,
+    # and megadetector loads it through this package. Upstream treats each
+    # YOLO backend as an optional extra and dropped this one as a dependency
+    # in 10.0.20, so we pin it here; without it cedar fails to load at all.
+    # 10.0.23 is also the first release that runs cedar correctly: before it,
+    # cedar's anchor-free output went through the YOLOv5-shaped NMS, which
+    # read anchor positions as class ids and failed every batch. That crashed
+    # process_video with "exit code 1" and made images silently return
+    # nothing (beta report 2026-07-30).
+    - yolov9pip==0.0.4
     - ultralytics==8.3.177

--- a/backend/app/ml/envs/addaxai-base/windows/environment.yml
+++ b/backend/app/ml/envs/addaxai-base/windows/environment.yml
@@ -14,7 +14,7 @@ dependencies:
     # GPU acceleration is available out of the box, including RTX
     # 50-series (Blackwell, sm_120) with native kernels instead of the
     # slow PTX JIT fallback. Needs NVIDIA driver >= 555. torch 2.8 still
-    # satisfies megadetector 10.0.18: it dropped the old `mkl<=2021.4.0`
+    # satisfies megadetector 10.0.24: it dropped the old `mkl<=2021.4.0`
     # Windows pin (so megadetector's `mkl==2024.0` resolves) and is not
     # 2.4.0 (which ultralytics 8.3.177 excludes on win32, `torch!=2.4.0`).
     # torchvision 0.23.0 is the matching release. Use --extra-index-url
@@ -49,7 +49,17 @@ dependencies:
     # cannot load the Windows certificate store (ssl ASN1 error, beta
     # report 2026-06-10). Installing a wheel skips setup.py entirely.
     - ultralytics-yolov5 @ https://huggingface.co/Addax-Data-Science/pip-wheels/resolve/main/ultralytics_yolov5-0.1.1-py3-none-any.whl#sha256=d532e62d6d7cd6c7381e4453810f31f10fd269cf9f237494bc570e74168dc2e1
-    - megadetector==10.0.18
+    - megadetector==10.0.24
+    # MDv1000-cedar is the only model in the zoo with a YOLOv9 architecture,
+    # and megadetector loads it through this package. Upstream treats each
+    # YOLO backend as an optional extra and dropped this one as a dependency
+    # in 10.0.20, so we pin it here; without it cedar fails to load at all.
+    # 10.0.23 is also the first release that runs cedar correctly: before it,
+    # cedar's anchor-free output went through the YOLOv5-shaped NMS, which
+    # read anchor positions as class ids and failed every batch. That crashed
+    # process_video with "exit code 1" and made images silently return
+    # nothing (beta report 2026-07-30).
+    - yolov9pip==0.0.4
     - ultralytics==8.3.177
 
     # Helps Windows pip use the system certificate store (matches the


### PR DESCRIPTION
Every detection failed on cedar, and had done since the model was added. On videos that surfaced as "Video detection failed with exit code 1" (beta report 2026-07-30). On images it was worse, because nothing crashed: each file was recorded as a MegaDetector failure entry, skipped at ingest, and the run completed reporting no animals.

Cedar is the only model in the zoo with a YOLOv9 architecture, so it is the only one megadetector loads through its yolov9 path. Its head is anchor-free and emits [batch, 4 + classes, anchors], (1, 7, 5040) here. megadetector's own nms() assumes the YOLOv5 layout, [batch, anchors, 5 + classes] with an objectness score at index 4, and 10.0.18 only routed to the model library's non_max_suppression when the loader was ultralytics. yolov9 fell through to that YOLOv5-shaped nms(), which read anchor positions as class ids and raised on every batch:

    Warning: batch inference failed for shape (384, 640, 3):
    '5022 is not a valid class.'

The whole batch was then marked detections: None, and process_video
iterated it: TypeError: 'NoneType' object is not iterable, exit 1.

Larch and sorrel have the identical anchor-free layout and were never affected, because they load as ultralytics and ultralytics was on the allowlist. Redwood, spruce and both v5 models are anchor-based and use the correct path. Cedar was alone in the gap.

Fixed upstream in megadetector 10.0.23, which routes yolov9 to the library nms as well. Two lines are needed here, not one: megadetector dropped yolov9pip as a dependency in 10.0.20, treating each YOLO backend as an optional extra, so bumping the version alone takes cedar from "returns garbage" to "does not load". Pinning it back is not new exposure, it is what 10.0.18 already installed transitively.

Verified by building a clean env from these files with the same micromamba the app uses, then running the failing command through it: exit 0, five detections, top confidence 0.924, where 10.0.18 reproduced the reported traceback byte for byte. Every other detector returns identical confidences on the same two images before and after, which is expected: the only dependency difference between 10.0.18 and 10.0.24 is the removal of yolov9pip, and yolov9pip declares no dependencies of its own, so the closure is unchanged. The torch rationale comments in the linux and windows files named the old version, and their claim still holds: 10.0.24 still declares mkl==2024.0 off darwin and still declares no torch constraint.

Editing these files changes their hash, so drift detection fires and existing users are offered the env rebuild. Until they take it they still have the bug, and anyone who ran cedar on images needs a re-analysis rather than a reprocess, since no detections ever reached the database.

Only the macOS clean build has been run. Windows and linux pull CUDA torch from the pytorch.org index and still need the same check.