### PR TITLE
Keep the add-label slideout open while a dialog covers the grid

### DIFF
--- a/frontend/src/components/verify/LabelsTab.tsx
+++ b/frontend/src/components/verify/LabelsTab.tsx
@@ -1376,6 +1376,17 @@ export function LabelsTab({
   useEffect(() => {
     if (selectedIds.size === 0) return;
     function handleClick(e: MouseEvent) {
+      // A modal layer is open, so nothing behind it is a grid background
+      // click. Its overlay is not part of the grid, and a drag that
+      // starts inside the dialog and ends on the overlay fires `click`
+      // on their common ancestor, which is <body>. Both reached
+      // clearSelection below, which unmounts the BulkActionBar and the
+      // add-custom-label slideout living inside it: the sheet vanished
+      // mid-edit with no exit animation and no onOpenChange. Selecting
+      // text right to left in the sheet hit this constantly, because
+      // the sheet's left edge is the only boundary a drag can cross and
+      // it sits ~25px from the fields.
+      if (document.querySelector("[role='dialog'],[role='alertdialog']")) return;
       const el = e.target as HTMLElement;
       if (el.closest("[data-crop-card], button, a, input, select, [role='menu'], [role='dialog'], [data-radix-popper-content-wrapper]")) return;
       clearSelection();


### PR DESCRIPTION
The slideout was not closing, it was being unmounted. The Labels page clears the crop selection on any document click whose target does not look like a control, and the bulk action bar, which renders the label picker and the taxonomy sheet inside it, returns null once the selection is empty.

Two clicks reached that path. A drag that starts in the sheet and ends on the overlay fires click on the common ancestor of the two, which is body. A plain click on the dimmed page targets the overlay itself. Neither matched the keep-selection selector, so both cleared the selection and destroyed the sheet mid-edit, with no exit animation and no onOpenChange, which is why the Radix-level guards added earlier never helped.

Selecting text right to left hit this constantly: the sheet sits on the right edge, so its left edge is the only boundary a drag can cross, and it is about 25px from the fields.

Suppress the deselect while any dialog is open. Nothing behind a modal is a grid background click.