### PR TITLE
Fix the app failing to start when port 8000 is in use

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -539,13 +539,17 @@ def create_app() -> FastAPI:
             )
 
     # CORS middleware - allow frontend to access API
-    # In Electron: frontend and backend both served from port 8000 (same origin)
-    # In dev: frontend on Vite dev server (5173), backend on 8000
+    # In Electron: frontend and backend both served from the API port (same origin)
+    # In dev: frontend on Vite dev server (5173), backend on the API port
+    #
+    # These follow settings.api_port rather than a literal: the port is
+    # configurable (API_PORT), and entries pinned to 8000 would stop matching
+    # the moment the backend was moved off it.
     app.add_middleware(
         CORSMiddleware,
         allow_origins=[
-            "http://localhost:8000",  # Electron app (same origin)
-            "http://127.0.0.1:8000",  # Electron app (same origin)
+            f"http://localhost:{settings.api_port}",  # Electron app (same origin)
+            f"http://127.0.0.1:{settings.api_port}",  # Electron app (same origin)
             "http://localhost:3000",
             "http://127.0.0.1:3000",
             "http://localhost:5173",  # Vite dev server

--- a/backend/run_server.py
+++ b/backend/run_server.py
@@ -18,12 +18,22 @@ if getattr(sys, 'frozen', False):
 if __name__ == "__main__":
     import uvicorn
 
+    from app.core.config import get_settings
+
     # Start uvicorn server
-    # Configuration is handled by app/core/config.py with sensible defaults
+    # Configuration is handled by app/core/config.py with sensible defaults.
+    #
+    # The port MUST come from settings rather than a literal. Electron picks
+    # the port and passes it down as API_PORT (see spawnBackend in
+    # electron/src/main.ts), then waits for /health on that same port. A
+    # hardcoded 8000 here meant the packaged backend ignored the setting, so
+    # the app could not be moved off a port another application already held.
+    settings = get_settings()
+
     uvicorn.run(
         "app.main:app",
         host="127.0.0.1",
-        port=8000,
+        port=settings.api_port,
         log_level="info",
         reload=False,
     )

--- a/backend/tests/api/test_cors_api_port.py
+++ b/backend/tests/api/test_cors_api_port.py
@@ -1,0 +1,58 @@
+"""Verify the CORS allow-list follows the configured API port.
+
+The Electron app picks the backend port (ADDAXAI_BACKEND_PORT) and passes
+it to the backend as API_PORT, so the renderer is served from whatever
+port the backend bound. CORS origins pinned to a literal 8000 stopped
+matching as soon as the port moved, which is exactly the case this
+setting exists to support.
+
+Preflight is answered by CORSMiddleware itself, so these never reach a
+route and need no database.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _preflight(origin: str) -> str | None:
+    """Send a CORS preflight from `origin`, return the allow-origin header."""
+    from app.main import create_app
+
+    client = TestClient(create_app())
+    response = client.options(
+        "/api/logs",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    return response.headers.get("access-control-allow-origin")
+
+
+def test_configured_port_is_an_allowed_origin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A renderer served from the configured port is allowed."""
+    monkeypatch.setenv("API_PORT", "8123")
+    assert _preflight("http://localhost:8123") == "http://localhost:8123"
+    assert _preflight("http://127.0.0.1:8123") == "http://127.0.0.1:8123"
+
+
+def test_default_port_is_not_allowed_once_the_port_moves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The old default is not left in the allow-list.
+
+    Guards the regression directly: if 8000 were still hardcoded here it
+    would pass this origin regardless of the setting.
+    """
+    monkeypatch.setenv("API_PORT", "8123")
+    assert _preflight("http://localhost:8000") is None
+
+
+def test_vite_dev_server_is_always_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Moving the port must not lock out the dev server on 5173."""
+    monkeypatch.setenv("API_PORT", "8123")
+    assert _preflight("http://localhost:5173") == "http://localhost:5173"

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -301,6 +301,34 @@ function isAddaxaiHealth(body: HealthBody | null): boolean {
 }
 
 /**
+ * Is anything at all listening on `port`?
+ *
+ * A plain TCP connect, deliberately not an HTTP request. probeHealth
+ * only reports a server that answers /health with 200, so a foreign
+ * process on the port is indistinguishable from a free port there: a
+ * bare 404 is the common case and it reads as "nothing here". This asks
+ * the only question that matters before we try to bind.
+ *
+ * Cheap enough for the startup path (a loopback connect either lands or
+ * is refused immediately), which is why it is not the netstat/lsof scan
+ * that killProcessOnPort needs to identify a pid.
+ */
+function isPortOccupied(port: number, timeoutMs = 1000): Promise<boolean> {
+  const net = require('net');
+  return new Promise((resolve) => {
+    const socket = net.connect({ host: '127.0.0.1', port, family: 4 });
+    const finish = (occupied: boolean) => {
+      socket.destroy();
+      resolve(occupied);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => finish(true));
+    socket.once('timeout', () => finish(false));
+    socket.once('error', () => finish(false));
+  });
+}
+
+/**
  * Kill whatever process is *listening* on `port`. Best-effort and
  * guarded: a missing tool or no-match just logs and returns. Only ever
  * called once we have already confirmed (via /health) that the listener
@@ -470,24 +498,31 @@ function spawnBackend(): void {
  */
 async function ensureBackend(): Promise<void> {
   const existing = await probeHealth(1500);
-  if (existing) {
-    if (isAddaxaiHealth(existing)) {
-      console.warn(
-        `[Electron] A backend is already on port ${BACKEND_PORT} ` +
-          `(version ${existing.version}); reclaiming the port.`,
-      );
-      killProcessOnPort(BACKEND_PORT);
-      // Wait for the port to actually free up (max ~5s).
-      for (let i = 0; i < 10; i++) {
-        if (!(await probeHealth(500))) break;
-        await delay(500);
-      }
-    } else {
-      throw new Error(
-        `Port ${BACKEND_PORT} is in use by another application. Quit ` +
-          `whatever is using it and relaunch AddaxAI.`,
-      );
+  if (existing && isAddaxaiHealth(existing)) {
+    console.warn(
+      `[Electron] A backend is already on port ${BACKEND_PORT} ` +
+        `(version ${existing.version}); reclaiming the port.`,
+    );
+    killProcessOnPort(BACKEND_PORT);
+    // Wait for the port to actually free up (max ~5s).
+    for (let i = 0; i < 10; i++) {
+      if (!(await probeHealth(500))) break;
+      await delay(500);
     }
+  } else if (await isPortOccupied(BACKEND_PORT)) {
+    // Something that is not us holds the port. Ask at the TCP level
+    // rather than trusting /health: a foreign server that answers
+    // anything other than 200 leaves probeHealth null, and a plain 404
+    // is the common case. That read as "port free", so we spawned a
+    // backend that could not bind and the user got a bare exit code
+    // instead of the reason. Naming the override matters as much as the
+    // diagnosis, because quitting the other application is not an
+    // option when it is a service that restarts on every boot.
+    throw new Error(
+      `Port ${BACKEND_PORT} is in use by another application. Quit ` +
+        `whatever is using it and relaunch AddaxAI, or set ` +
+        `ADDAXAI_BACKEND_PORT to a free port.`,
+    );
   }
 
   spawnBackend();

--- a/electron/tests/startup-recovery.spec.ts
+++ b/electron/tests/startup-recovery.spec.ts
@@ -18,6 +18,7 @@
 import { test, expect } from '@playwright/test';
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
+import * as http from 'http';
 import * as os from 'os';
 import * as path from 'path';
 import { launch as launchApp, makeHealthyDb, appWindow } from './app-harness';
@@ -94,6 +95,45 @@ test('a slow start says so, and never offers to start a second backend', async (
     .toContain(`localhost:${PORT}`);
 
   await app.close();
+});
+
+test('a port held by another application names the port, not an exit code', async () => {
+  /**
+   * The reported case: an unrelated service holds the backend port and
+   * answers 404 on /health. probeHealth only accepts a 200, so it
+   * returned null, the app read that as "port free", spawned a backend
+   * that could not bind, and showed "The backend stopped while starting
+   * up (exit code 1)". The port never got a mention, so the user had no
+   * way to know that ADDAXAI_BACKEND_PORT was the way out.
+   */
+  makeHealthyDb(userDataDir);
+
+  const squatter = http.createServer((_req, res) => {
+    res.statusCode = 404;
+    res.end('not found');
+  });
+  await new Promise<void>((resolve) => {
+    squatter.listen(Number(PORT), '127.0.0.1', resolve);
+  });
+
+  try {
+    const app = await launch();
+    const win = await appWindow(app);
+
+    await expect(win.locator('h1')).toHaveText('AddaxAI could not start', {
+      timeout: 60_000,
+    });
+    await expect(win.locator('.reason')).toContainText(
+      `Port ${PORT} is in use by another application`,
+    );
+    // The way out has to be on the page. Quitting the other application
+    // is not always possible.
+    await expect(win.locator('.reason')).toContainText('ADDAXAI_BACKEND_PORT');
+
+    await app.close();
+  } finally {
+    await new Promise<void>((resolve) => squatter.close(() => resolve()));
+  }
 });
 
 test('a broken database shows the reason and the recovery buttons', async () => {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -9,7 +9,19 @@
 
 import { logger } from "./logger";
 
-export const API_BASE_URL = import.meta.env.VITE_API_URL || "http://127.0.0.1:8000";
+/**
+ * Base URL for every API call, image, and WebSocket.
+ *
+ * The fallback is the current origin, not a literal port. In the packaged app
+ * the backend serves this SPA, so the origin already IS the backend and the
+ * two stay together wherever the port lands. A hardcoded 127.0.0.1:8000 was
+ * baked in at build time, so moving the backend off 8000 broke every request.
+ *
+ * Dev still overrides this with VITE_API_URL to reach the backend from the
+ * Vite dev server on 5173. Keep it absolute: useTaskProgress parses it with
+ * `new URL()` to derive the WebSocket URL.
+ */
+export const API_BASE_URL = import.meta.env.VITE_API_URL || window.location.origin;
 
 /**
  * Error thrown when the API returns a non-2xx response. Preserves the

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -17,9 +17,11 @@ import { logger } from "./logger";
  * two stay together wherever the port lands. A hardcoded 127.0.0.1:8000 was
  * baked in at build time, so moving the backend off 8000 broke every request.
  *
- * Dev still overrides this with VITE_API_URL to reach the backend from the
- * Vite dev server on 5173. Keep it absolute: useTaskProgress parses it with
- * `new URL()` to derive the WebSocket URL.
+ * Dev is the other way round, because there Vite serves the SPA and the backend
+ * is elsewhere. VITE_API_URL addresses it directly; with no .env the origin is
+ * the dev server, which proxies both /api and /ws onward (see vite.config.ts).
+ * Keep it absolute: useTaskProgress parses it with `new URL()` to derive the
+ * WebSocket URL.
  */
 export const API_BASE_URL = import.meta.env.VITE_API_URL || window.location.origin;
 

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -103,7 +103,9 @@ class Logger {
     this.buffer = [];
 
     try {
-      const API_BASE_URL = import.meta.env.VITE_API_URL || "http://127.0.0.1:8000";
+      // Same fallback as lib/api-client.ts. Resolved here rather than imported
+      // because api-client imports this logger, and the two would form a cycle.
+      const API_BASE_URL = import.meta.env.VITE_API_URL || window.location.origin;
 
       await fetch(`${API_BASE_URL}/api/logs`, {
         method: "POST",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,6 +22,15 @@ export default defineConfig({
         target: 'http://localhost:8000',
         changeOrigin: true,
       },
+      // The job WebSocket lives outside /api, so it needs its own entry.
+      // Without it, a dev server with no .env resolves API_BASE_URL to the
+      // Vite origin, ws://localhost:5173/ws/jobs/... reaches nothing, and a
+      // job never starts: the backend waits for the socket's ready message
+      // before it begins work.
+      '/ws': {
+        target: 'ws://localhost:8000',
+        ws: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## What happened

I installed the Windows build from the releases page (v7.0.5) and it would not
launch. The splash sat for a few seconds, then:

> **AddaxAI could not start**
> The backend stopped while starting up (exit code 1). See the logs for details.

`backend.log` had the real reason, but the app never surfaced it:

```
[ERROR] [uvicorn.error] [Errno 10048] error while attempting to bind on
address ('127.0.0.1', 8000): only one usage of each socket address
(protocol/network address/port) is normally permitted
```

Another process on my machine holds `127.0.0.1:8000`. It is a managed service
that starts with Windows and comes back on every boot, so "quit whatever is
using it" is not something I can act on.

## Two faults

**1. The port could not be moved.** `ADDAXAI_BACKEND_PORT` already exists and
the Electron side already honours it: `main.ts` reads it, passes it down as
`API_PORT`, and waits for `/health` on that port. The packaged backend then
ignored it, because `run_server.py` passed uvicorn a literal `port=8000`.
Setting the variable made things worse rather than better, since Electron would
wait on a port nothing was ever going to answer on.

I confirmed this against the shipped binary rather than only in source. Running
the installed `resources/backend/backend.exe` with `API_PORT=8123` (isolated via
`USER_DATA_DIR`) still tried to bind 8000 and exited 1.

**2. The occupied port was never diagnosed.** `ensureBackend` already has the
right message, `Port 8000 is in use by another application`, but it can only
fire when `probeHealth` returns a body, and `probeHealth` treats anything other
than a 200 as nothing at all. The service on my port answers **404**, so the
probe returned `null`, the app concluded the port was free, spawned a backend
that could not bind, and fell through to the generic exit-code message. A
foreign HTTP server that does not return 200 on `/health` is the ordinary case,
not an edge case.

## What changed

| File | Change |
|---|---|
| `backend/run_server.py` | Port comes from `settings.api_port` instead of a literal |
| `backend/app/main.py` | CORS origins follow `settings.api_port` |
| `frontend/src/lib/api-client.ts` | API base falls back to the current origin |
| `frontend/src/lib/logger.ts` | Same fallback |
| `electron/src/main.ts` | Detect an occupied port over TCP, and name the override |
| `frontend/vite.config.ts` | Proxy `/ws` in dev, not only `/api` |

The frontend had `http://127.0.0.1:8000` baked into the bundle at build time, so
every request, image and WebSocket would have kept going to 8000 even once the
backend moved. It now falls back to `window.location.origin`, which in the
packaged app is the backend serving the SPA. `VITE_API_URL` still overrides it
for dev. It stays absolute because `useTaskProgress` derives the WebSocket URL
from it with `new URL()`.

That fallback also needed `/ws` proxied in dev. With no `.env` of your own the
origin is the Vite dev server, and while `/api` was already proxied, `/ws` was
not, so the job socket reached nothing. Since the backend waits for that
socket's ready message before starting work, a job would not have begun at all.
The `/ws` rule closes that, and keeps the port in one place rather than putting
the `8000` literal back into the client.

For detection I used a plain loopback TCP connect rather than reusing the
`netstat`/`lsof` scan in `killProcessOnPort`. That scan runs a subprocess, and
this check sits on every startup; a connect either lands or is refused
immediately. `killProcessOnPort` is untouched.

No change was needed on the Electron side beyond that. The comment in
`spawnBackend` already claimed the packaged backend "binds the port itself from
this setting". That is now true rather than aspirational.

## Verification

All four CI gates pass. The backend failure set is byte-identical to a baseline
I captured before making any changes (the failures are Windows-only: missing
exiftool and POSIX path assumptions).

Against a packaged Windows build, with a foreign server holding the port:

- **Occupied port:** `Port 8131 is in use by another application. Quit whatever
  is using it and relaunch AddaxAI, or set ADDAXAI_BACKEND_PORT to a free port.`
  Previously this produced `exit code 1`.
- **Free port:** clean start in two seconds, window opens, and the SPA's own
  calls to `/api/setup/status` and `/api/ml/updates` return 200 on that port.
  That last part is what proves the frontend change at runtime.
- **No `API_PORT` set:** still binds 8000. The default is unchanged, so this is
  purely additive.

The three new CORS tests fail against the old hardcoded allow-list and pass
against the new one, so they are real guards rather than vacuous.

## Notes for review

- **The e2e test has not been run.** `resolveBackendCommand` hardcodes
  `venv/bin/python`, so the unpackaged app the Playwright harness launches does
  not start on Windows, and CI does not run the e2e suite. That test will
  execute for the first time on your machine. I verified the same behaviour
  manually against the packaged app instead.
- **One case changes shape.** A stale backend too wedged to answer `/health`
  within 1500ms is now reported as another application rather than reclaimed,
  which misattributes it. I think that is still the better failure, because the
  old path spawned a second backend against the same SQLite file, which is the
  race `waitForBackend` warns about.
- **Deliberately left out:** `DEVELOPERS.md` (it already describes the variable
  accurately, and only becomes more accurate), `.env.example` (dev-only,
  unaffected), and the `API_BASE_URL` duplication between `api-client.ts` and
  `logger.ts` (pre-existing, and cannot be collapsed without an import cycle).
